### PR TITLE
Add built-in support for time.Time

### DIFF
--- a/deepcopy.go
+++ b/deepcopy.go
@@ -7,6 +7,7 @@
 package deepcopy
 
 import "reflect"
+import "time"
 
 // Iface is an alias to Copy; this exists for backwards compatibility reasons.
 func Iface(iface interface{}) interface{} {
@@ -64,6 +65,20 @@ func copyRecursive(original, cpy reflect.Value) {
 		cpy.Set(copyValue)
 
 	case reflect.Struct:
+		t, ok := original.Interface().(time.Time)
+		if ok {
+			b, err := t.MarshalBinary()
+			if err != nil {
+				panic(err)
+			}
+			tcpy := time.Time{}
+			tcpy.UnmarshalBinary(b)
+			if err != nil {
+				panic(err)
+			}
+			cpy.Set(reflect.ValueOf(tcpy))
+			return
+		}
 		// Go through each field of the struct and copy it.
 		for i := 0; i < original.NumField(); i++ {
 			// The Type's StructField for a given field is checked to see if StructField.PkgPath

--- a/deepcopy_test.go
+++ b/deepcopy_test.go
@@ -3,6 +3,7 @@ package deepcopy
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 // just basic is this working stuff
@@ -670,6 +671,7 @@ type A struct {
 	MapB   map[string]*B
 	SliceB []*B
 	B
+	T time.Time
 }
 
 type B struct {
@@ -689,6 +691,7 @@ var AStruct = A{
 		&B{Vals: []string{"Ciao", "Aloha"}},
 	},
 	B: B{Vals: []string{"42"}},
+	T: time.Now(),
 }
 
 func TestStructA(t *testing.T) {
@@ -795,20 +798,28 @@ ASliceB:
 B:
 	if fmt.Sprintf("%p", &AStruct.B) == fmt.Sprintf("%p", &a.B) {
 		t.Error("A.B: expected them to have different addresses, they didn't")
-		return
+		goto T
 	}
 	if fmt.Sprintf("%p", AStruct.B.Vals) == fmt.Sprintf("%p", a.B.Vals) {
 		t.Error("A.B.Vals: expected them to have different addresses, they didn't")
-		return
+		goto T
 	}
 	if len(AStruct.B.Vals) != len(a.B.Vals) {
 		t.Error("A.B.Vals: expected their lengths to be the same, they weren't")
-		return
+		goto T
 	}
 	for i, v := range AStruct.B.Vals {
 		if v != a.B.Vals[i] {
 			t.Errorf("A.B.Vals[%d]: got %s want %s", i, a.B.Vals[i], v)
 		}
+	}
+T:
+	if fmt.Sprintf("%p", &AStruct.T) == fmt.Sprintf("%p", &a.T) {
+		t.Error("A.T: expected them to have different addresses, they didn't")
+		return
+	}
+	if AStruct.T != a.T {
+		t.Errorf("A.T: got %v, want %v", a.T, AStruct.T)
 	}
 }
 


### PR DESCRIPTION
Hi,

Following on https://github.com/mohae/deepcopy/issues/2 we added support for time.Time in our fork.

We first tried and make it a bit more general, like querying a 'Copier' interface on values to see if the user wanted to hook the copy, however given the lack of overloading in go and the fact that a member function cannot be added outside of the package of a type, it wasn't very useful for time.Time.
Alternatively we could query for the encoding.BinaryMarshaler or gob.GobEncoder interfaces but this will likely change the semantics of deepcopy to copy way more than expected by the user.

Thanks!