### PR TITLE
preserve nil slices and maps

### DIFF
--- a/deepcopy.go
+++ b/deepcopy.go
@@ -76,6 +76,9 @@ func copyRecursive(original, cpy reflect.Value) {
 		}
 
 	case reflect.Slice:
+		if original.IsNil() {
+			return
+		}
 		// Make a new slice and copy each element.
 		cpy.Set(reflect.MakeSlice(original.Type(), original.Len(), original.Cap()))
 		for i := 0; i < original.Len(); i++ {
@@ -83,6 +86,9 @@ func copyRecursive(original, cpy reflect.Value) {
 		}
 
 	case reflect.Map:
+		if original.IsNil() {
+			return
+		}
 		cpy.Set(reflect.MakeMap(original.Type()))
 		for _, key := range original.MapKeys() {
 			originalValue := original.MapIndex(key)

--- a/deepcopy_test.go
+++ b/deepcopy_test.go
@@ -666,6 +666,7 @@ type A struct {
 	String string
 	UintSl []uint
 	NilSl  []string
+	NilMap map[string]string
 	Map    map[string]int
 	MapB   map[string]*B
 	SliceB []*B
@@ -714,6 +715,14 @@ func TestStructA(t *testing.T) {
 	}
 	if len(a.UintSl) != len(AStruct.UintSl) {
 		t.Errorf("A.UintSl: got len of %d, want %d", len(a.UintSl), len(AStruct.UintSl))
+		goto AMap
+	}
+	if a.NilSl != nil {
+		t.Errorf("A.NilSl: nil slice expected")
+		goto AMap
+	}
+	if a.NilMap != nil {
+		t.Errorf("A.NilSl: nil map expected")
 		goto AMap
 	}
 	for i, v := range AStruct.UintSl {


### PR DESCRIPTION
Hi,

Here is a fix to preserve nil slices and maps when deep copying instead of instantiating empty slices and maps.