### PR TITLE
do not copy slice cap

### DIFF
--- a/deepcopy.go
+++ b/deepcopy.go
@@ -101,7 +101,7 @@ func copyRecursive(original, cpy reflect.Value) {
 			return
 		}
 		// Make a new slice and copy each element.
-		cpy.Set(reflect.MakeSlice(original.Type(), original.Len(), original.Cap()))
+		cpy.Set(reflect.MakeSlice(original.Type(), original.Len(), original.Len()))
 		for i := 0; i < original.Len(); i++ {
 			copyRecursive(original.Index(i), cpy.Index(i))
 		}

--- a/deepcopy_test.go
+++ b/deepcopy_test.go
@@ -1108,3 +1108,11 @@ func TestInterface(t *testing.T) {
 		t.Errorf("expected value %v, but it's %v", "custom copy", copiedNest.I.A)
 	}
 }
+
+func TestSliceCap(t *testing.T) {
+	s := make([]int, 0, 10)
+	ns := Copy(s).([]int)
+	if cap(ns) != 0 {
+		t.Errorf("expected cap(ns) == 0, got %d", cap(ns))
+	}
+}


### PR DESCRIPTION
Copying slice cap is not necessary and will cause extra memory usages if there are multiple slices derived from the same underlying array.