### PR TITLE
Basic struct tags support: skip field, assign field

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,18 @@ DeepCopy makes deep copies of things: unexported field values are not copied.
 
 ## Usage
     cpy := deepcopy.Copy(orig)
+
+## Tags
+
+The following struct tags is supported:
+
+```
+type A struct {
+    Field1 SomeType  `deepcopy:"-"` // skip, will have zero-value in copy
+    Field2 *SomeType `deepcopy:"="` // treat like with "=" assignment operator
+}
+```
+
+Specifically the `=` tag is usable when you want to copy a struct containing
+something like `*sync.Mutex` or `*os.File` and don't want it to be deeply copied
+but simply assigned.

--- a/deepcopy.go
+++ b/deepcopy.go
@@ -87,12 +87,22 @@ func copyRecursive(original, cpy reflect.Value) {
 		}
 		// Go through each field of the struct and copy it.
 		for i := 0; i < original.NumField(); i++ {
+			field := original.Type().Field(i)
 			// The Type's StructField for a given field is checked to see if StructField.PkgPath
 			// is set to determine if the field is exported or not because CanSet() returns false
 			// for settable fields.  I'm not sure why.  -mohae
-			if original.Type().Field(i).PkgPath != "" {
+			if field.PkgPath != "" {
 				continue
 			}
+
+			switch field.Tag.Get("deepcopy") {
+			case "-":
+				continue
+			case "=":
+				cpy.Field(i).Set(original.Field(i))
+				continue
+			}
+
 			copyRecursive(original.Field(i), cpy.Field(i))
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mtfelian/deepcopy
+
+go 1.12


### PR DESCRIPTION
Introduced basic struct tags support. 

- Use tag `deepcopy:"-"` to skip copying of a struct field (will be zero-valued); 
- Use tag `deepcopy:"="` to assign the field, it is specifically needed when you don't want to deep copy a pointer something like `*os.File` in the struct field. 